### PR TITLE
Fix version information display in released binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,7 +114,8 @@ jobs:
         BUILD_TIME: $(date -u +%Y-%m-%dT%H:%M:%SZ)
       run: |
         BUILD_TIME=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-        go build -ldflags "-X main.Version=$VERSION -X main.BuildTime=$BUILD_TIME -s -w" -o ${{ matrix.artifact_name }} .
+        # Fixed: Use proper ldflags syntax with quotes and pass to cmd package variables
+        go build -ldflags "-X 'main.Version=$VERSION' -X 'main.BuildTime=$BUILD_TIME' -X 'github.com/aywengo/ksr-cli/cmd.Version=$VERSION' -X 'github.com/aywengo/ksr-cli/cmd.BuildTime=$BUILD_TIME' -s -w" -o ${{ matrix.artifact_name }} .
     
     - name: Upload artifact
       uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Description
This PR fixes the version information display issue where `ksr-cli --version` shows "dev" instead of the actual version number.

## Problem
When installing ksr-cli via Homebrew, the version information is not properly embedded:
```
$ ksr-cli --version
ksr-cli version dev
Built at: unknown
```

## Root Cause
The ldflags in the release workflow were not properly formatted, causing the version variables to not be set during the build process.

## Solution
1. Added quotes around the ldflags values to ensure proper parsing
2. Set version information for both `main.Version` and `cmd.Version` variables (since the version is passed from main to cmd package)
3. This ensures the version information is properly embedded in the binary during the build process

## Changes Made
- Updated `.github/workflows/release.yml` to fix the ldflags syntax in the build step
- Changed from: `-ldflags "-X main.Version=$VERSION -X main.BuildTime=$BUILD_TIME -s -w"`
- Changed to: `-ldflags "-X 'main.Version=$VERSION' -X 'main.BuildTime=$BUILD_TIME' -X 'github.com/aywengo/ksr-cli/cmd.Version=$VERSION' -X 'github.com/aywengo/ksr-cli/cmd.BuildTime=$BUILD_TIME' -s -w"`

## Testing
After this fix is merged and a new release is created, the version should display correctly:
```
$ ksr-cli --version
ksr-cli version v0.1.2
Built at: 2025-06-15T20:56:38Z
```

Fixes #4